### PR TITLE
path and current_doc fixes

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,9 +16,9 @@ following parameters are available:
 ``count``
   Number of recent revisions to return (default from :confval:`recentupdate_count`).
 
-``path``
-  A git pathspec (:manpage:`gitglossary(7)`) to filter file changes
-  (default ``'.'``).
+``paths``
+  A list of git pathspecs (:manpage:`gitglossary(7)`) to filter file changes
+  (default ``['.']``).
   See also :example:`Recent Updates of Custom Path`.
 
 ``current_doc``
@@ -89,7 +89,7 @@ Examples
 
       Recent changes of the ``docs/index.rst`` file:
 
-      {% for r in load_extra('recentupdate', count=5, path='docs/index.rst') %}
+      {% for r in load_extra('recentupdate', count=5, paths=['docs/index.rst']) %}
       ``{{ r.date }}`` — {{ r.message[0] }}
       {% endfor %}
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,8 +23,14 @@ following parameters are available:
 
 ``current_doc``
   If ``True``, only return revisions that modified the current document
-  (default ``False``).
+  (default ``False``). When enabled, ``paths`` is overridden with a pathspec
+  matching the current document.
   See also :example:`Recent Updates to Current Document`.
+
+.. note::
+
+   ``paths`` and ``current_doc`` are mutually exclusive. When ``current_doc=True``,
+   the ``paths`` parameter is ignored.
 
 .. role:: py(code)
   :language: Python

--- a/src/sphinxnotes/recentupdate/__init__.py
+++ b/src/sphinxnotes/recentupdate/__init__.py
@@ -14,13 +14,11 @@ from datetime import datetime, timezone
 from dataclasses import dataclass
 from collections import OrderedDict
 from os import path
-from pathlib import Path
 from itertools import islice
 
 from git import Repo
 
 from sphinx.util import logging
-from sphinx.util.matching import Matcher
 from sphinx.config import ENUM
 
 from sphinxnotes.render import (
@@ -144,7 +142,7 @@ def get_git_revisions(
             for blob in cur.tree.traverse():
                 if blob.type != 'blob':
                     continue
-                docname = path2docname(repo, env, blob.path)
+                docname = path2doc(repo, env, blob.path)
                 if docname is None:
                     continue
                 a.append(docname)
@@ -168,7 +166,7 @@ def get_git_revisions(
                 if not line.strip():
                     continue
                 status, file_path = line.split('\t', 1)
-                docname = path2docname(repo, env, file_path)
+                docname = path2doc(repo, env, file_path)
                 if docname is None:
                     continue
 
@@ -191,28 +189,9 @@ def get_git_revisions(
         )
 
 
-def path2docname(repo: Repo, env: BuildEnvironment, file: str) -> str | None:
-    """Convert a repo-relative file path to a Sphinx docname."""
-    relsrcdir_to_repo = path.relpath(env.srcdir, repo.working_dir)
-    relfn_to_srcdir = path.relpath(file, relsrcdir_to_repo)
-    absfn = Path(repo.working_dir, file)
-    if not absfn.is_relative_to(env.srcdir):
-        logger.debug(f'Skip {file}: out of srcdir')
-        return None
-
-    excluded = Matcher(env.config.exclude_patterns)
-    if excluded(relfn_to_srcdir):
-        logger.debug(f'Skip {file}: excluded by exclude_patterns')
-        return None
-
-    docname, ext = path.splitext(relfn_to_srcdir)
-    source_suffix = list(env.config.source_suffix.keys())
-    if not ext or ext not in source_suffix:
-        logger.debug(f'Skip {file}: not {source_suffix} files')
-        return None
-
-    logger.debug(f'Get docname: {docname}')
-    return docname
+def path2doc(repo: Repo, env: BuildEnvironment, blob_path: str) -> str | None:
+    """Convert a git repo-relative blob path to a Sphinx document name. """
+    return env.path2doc(path.join(repo.working_dir, blob_path))
 
 
 @extra_context('recentupdate')

--- a/src/sphinxnotes/recentupdate/__init__.py
+++ b/src/sphinxnotes/recentupdate/__init__.py
@@ -48,16 +48,6 @@ class Revision:
     #: Git commit author date
     date: datetime
 
-    # FYI, possible status letters are:
-    # :A: addition of a file
-    # :C: copy of a file into a new one
-    # :D: deletion of a file
-    # :M: modification of the contents or mode of a file
-    # :R: renaming of a file
-    # :T: change in the type of the file
-    # :U: file is unmerged (you must complete the merge before it can be committed)
-    # :X: "unknown" change type (most probably a bug, please report it)
-
     #: List of docname, corresponding to files which are newly added
     added_docs: list[str]
     #: List of docname, corresponding to files which are modified
@@ -160,6 +150,17 @@ def get_git_revisions(
                     continue
                 a.append(docname)
         else:
+            # Possible status letters are:
+            # :A: addition of a file
+            # :C: copy of a file into a new one
+            # :D: deletion of a file
+            # :M: modification of the contents or mode of a file
+            # :R: renaming of a file
+            # :T: change in the type of the file
+            # :U: file is unmerged (you must complete the merge before it can be committed)
+            # :X: "unknown" change type (most probably a bug, please report it)
+            status_maps = {'M': m, 'A': a, 'D': d }
+
             # Use git diff --name-status with pathspecs for native pathspec matching
             name_status = repo.git.diff(
                 prev.hexsha, cur.hexsha, '--name-status', '--', *paths
@@ -172,17 +173,10 @@ def get_git_revisions(
                 if docname is None:
                     continue
 
-                if status == 'M':
-                    m.append(docname)
-                elif status == 'A':
-                    a.append(docname)
-                elif status == 'D':
-                    d.append(docname)
+                if status in status_maps:
+                    status_maps[status].append(docname)
                 else:
-                    logger.info(
-                        f'Skip {file_path}: '
-                        f'unsupported change type {status}'
-                    )
+                    logger.info(f'Skip {file_path}: unsupported change type {status}')
 
         if len(m) + len(a) + len(d) == 0:
             logger.debug(f'Skip commit {cur.hexsha}: no document changes')

--- a/src/sphinxnotes/recentupdate/__init__.py
+++ b/src/sphinxnotes/recentupdate/__init__.py
@@ -234,8 +234,9 @@ class RecentUpdateExtraContext(ExtraContext):
         group_by = group_by or req.env.config.recentupdate_group_by
 
         if current_doc:
-            docname = req.env.docname
-            paths = [docname + '.*']
+            docpath = req.env.doc2path(req.env.docname)
+            repo_path = path.relpath(docpath, self.repo.working_dir)
+            paths = [repo_path]
 
         git_revs = get_git_revisions(self.repo, req.env, paths)
 

--- a/src/sphinxnotes/recentupdate/__init__.py
+++ b/src/sphinxnotes/recentupdate/__init__.py
@@ -135,11 +135,11 @@ def compact_groups(
 def get_git_revisions(
     repo: Repo,
     env: BuildEnvironment,
-    path: str,
+    paths: list[str],
     current_doc: str | None = None,
 ) -> Iterator[Revision]:
     """Yield Revision objects from git commits."""
-    for cur in repo.iter_commits(paths=path):
+    for cur in repo.iter_commits(paths=paths):
         matches = [x in cur.message for x in env.config.recentupdate_exclude_commit]
         if any(matches):
             logger.debug(
@@ -232,7 +232,7 @@ class RecentUpdateExtraContext(ExtraContext):
         self,
         req: ExtraContextRequest,
         count: int = 0,
-        path: str = '.',
+        paths: list[str] = ['.', ],
         current_doc: bool = False,
         group_by: str = '',
     ) -> Any:
@@ -240,7 +240,7 @@ class RecentUpdateExtraContext(ExtraContext):
         group_by = group_by or req.env.config.recentupdate_group_by
         docname = req.env.docname if current_doc else None
 
-        git_revs = get_git_revisions(self.repo, req.env, path, docname)
+        git_revs = get_git_revisions(self.repo, req.env, paths, docname)
 
         if group_by:
             groups = OrderedDict()

--- a/src/sphinxnotes/recentupdate/__init__.py
+++ b/src/sphinxnotes/recentupdate/__init__.py
@@ -126,7 +126,6 @@ def get_git_revisions(
     repo: Repo,
     env: BuildEnvironment,
     paths: list[str],
-    current_doc: str | None = None,
 ) -> Iterator[Revision]:
     """Yield Revision objects from git commits."""
     for cur in repo.iter_commits(paths=paths):
@@ -181,9 +180,6 @@ def get_git_revisions(
         if len(m) + len(a) + len(d) == 0:
             logger.debug(f'Skip commit {cur.hexsha}: no document changes')
             continue
-        if current_doc is not None and current_doc not in (m + a + d):
-            logger.debug(f'Skip commit {cur.hexsha}: no changes to {current_doc}')
-            continue
 
         yield Revision(
             message=str(cur.message).splitlines(),
@@ -236,9 +232,12 @@ class RecentUpdateExtraContext(ExtraContext):
     ) -> Any:
         count = count or req.env.config.recentupdate_count
         group_by = group_by or req.env.config.recentupdate_group_by
-        docname = req.env.docname if current_doc else None
 
-        git_revs = get_git_revisions(self.repo, req.env, paths, docname)
+        if current_doc:
+            docname = req.env.docname
+            paths = [docname + '.*']
+
+        git_revs = get_git_revisions(self.repo, req.env, paths)
 
         if group_by:
             groups = OrderedDict()

--- a/src/sphinxnotes/recentupdate/__init__.py
+++ b/src/sphinxnotes/recentupdate/__init__.py
@@ -160,24 +160,28 @@ def get_git_revisions(
                     continue
                 a.append(docname)
         else:
-            diff_idx = prev.tree.diff(cur)
-            for diff in diff_idx:
-                if diff.a_path is None:
+            # Use git diff --name-status with pathspecs for native pathspec matching
+            name_status = repo.git.diff(
+                prev.hexsha, cur.hexsha, '--name-status', '--', *paths
+            )
+            for line in name_status.splitlines():
+                if not line.strip():
                     continue
-                docname = path2docname(repo, env, diff.a_path)
+                status, file_path = line.split('\t', 1)
+                docname = path2docname(repo, env, file_path)
                 if docname is None:
                     continue
 
-                if diff.change_type == 'M':
+                if status == 'M':
                     m.append(docname)
-                elif diff.change_type == 'A':
+                elif status == 'A':
                     a.append(docname)
-                elif diff.change_type == 'D':
+                elif status == 'D':
                     d.append(docname)
                 else:
                     logger.info(
-                        f'Skip {diff.a_path}: '
-                        f'unsupported change type {diff.change_type}'
+                        f'Skip {file_path}: '
+                        f'unsupported change type {status}'
                     )
 
         if len(m) + len(a) + len(d) == 0:

--- a/tests/roots/test-recentupdate-path-filter/index.rst
+++ b/tests/roots/test-recentupdate-path-filter/index.rst
@@ -4,6 +4,6 @@ Recentupdate Path Filter Test
 .. data.render::
    :debug:
 
-   {% for r in load_extra('recentupdate', count=10, path='subdir') %}
+   {% for r in load_extra('recentupdate', count=10, paths=['subdir']) %}
    Commit: {{ r.message[0] }}
    {% endfor %}


### PR DESCRIPTION
## Summary

- Add `group_by` option for grouping revisions by time period
- Rename `path` parameter to `paths` (list[str]) for better API design
- Fix pathspec matching by using `git diff` for native file filtering
- Introduce `status_map` refactoring for cleaner status handling
- Move `current_doc` logic to `generate()` for pathspec conversion
- Use `env.doc2path` / `env.path2doc` for accurate docname to path conversion
- Render list elements individually in e2e test templates