### PR TITLE
feat: Re-add recentupdate directive

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,15 +27,22 @@ Version 2.x
    - The template feature is now provided by
      :external+render:doc:`sphinxnotes-render <index>`. It offers richer features;
      Please see :external+render:doc:`tmpl`
-   - The extension now provides a ``recentupdate`` extra context for replacing 
-     the ``.. recentupdate::`` directive. See :doc:`usage` for more details
+   - The :rst:dir:`recentupdate`` directive supports more options:
+
+     - New ``:self:`` option: show only revisions that modified the
+       current document
+     - New ``:paths:`` option: Specifiy pathspecs to filter file changes
+     - New ``:group-by:`` option: group revisions by time period (day/month/year)
+
+   - Provide a ``recentupdate`` extra context for use within
+     ``sphinxnotes-render`` compatible templates
+   - New confval: ``recentupdate_group_by``
 
    BREAKING CHANGES:
 
-   - Drop the ``.. recentupdate::`` directive
-   - Drop the ``strftime`` and ``roles`` filters
-   - Drop the ``recentupdate_date_format``, ``recentupdate_template``, and
-     ``recentupdate_exclude_path`` confvals
+   - Drop the ``strftime`` filters, use ``datetime.strfime`` instead
+   - The ``roles`` filter is now provided by ``sphinxnotes-render``
+   - Drop the ``recentupdate_exclude_path``, ``recentupdate_date_format`` confval
    - The members of :py:class:`~sphinxnotes.recentupdate.Revision` are renamed
 
 Version 1.x

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -4,14 +4,21 @@ Configuration
 
 The extension provides the following configuration:
 
-.. autoconfval:: recentupdate_exclude_commit
-
-   A list of commit message pattern that should be excluded when looking for file changes.
-
 .. autoconfval:: recentupdate_count
 
    Number of recent revisions to return by default when calling
    ``load_extra('recentupdate')`` without an explicit ``count`` parameter.
+
+.. autoconfval:: recentupdate_template
+
+   Default Jinja2 template for the :rst:dir:`recentupdate` directive.
+   Used when the directive has no body content.
+   The template context contains ``revisions``, a list of
+   :py:class:`~sphinxnotes.recentupdate.Revision` objects.
+
+.. autoconfval:: recentupdate_exclude_commit
+
+   A list of commit message pattern that should be excluded when looking for file changes.
 
 .. autoconfval:: recentupdate_group_by
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,10 +29,10 @@ Introduction
 
 Get the Sphinx document update information from Git repository.
 
-This extension integrates with :external+render:doc:`sphinxnotes-render <index>`
-by providing an extra context ``recentupdate``. The recent document update
-information is read from a Git_ repository. You can customize the presentation
-via ``data.render`` template.
+This extension provides a :rst:dir:`recentupdate` directive that displays
+recent document update information read from a Git_ repository. It also
+integrates with :external+render:doc:`sphinxnotes-render <index>` by
+providing an extra context for use in render templates.
 
 .. _Git: https://git-scm.com/
 
@@ -71,20 +71,12 @@ Then, add the extension name to ``extensions`` configuration item in your
 
 .. ADDITIONAL CONTENT START
 
-Now you can use the :rst:dir:`data.render` directive (provided by
-``sphinxnotes.render.ext``) with ``recentupdate`` extra context to render
-a revision list:
+Now you can use the :rst:dir:`recentupdate` directive to render a revision list
+of the our documentation.
 
 .. example::
 
-   .. data.render::
-
-      The most recent 3 commits:
-
-      {% for r in load_extra('recentupdate', 3) %}
-      ``{{ r.date.strftime('%Y-%m-%d') }}``
-         {{ r.message[0] }}
-      {% endfor %}
+   .. recentupdate:: 3
 
 Please refer to :doc:`usage` for more details.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,49 +2,54 @@
 Usage
 =====
 
-The extension provides an extra context ``recentupdate`` for `sphinxnotes-render`_.
-Extra context can be load by the :external+render:term:`load_extra` function in
-a Jinja template. User can easily render a Jinja template via :rst:dir:`data.render`
-directive.
+The :rst:dir:`recentupdate` directive is the recommended way to display recent
+document updates. For cases where you need recent update information inside a
+`sphinxnotes-render`_ compatible template (e.g. alongside other extra contexts),
+use the ``recentupdate`` extra context instead.
 
-``recentupdate``
-================
+The ``recentupdate`` Directive
+==============================
 
-When calling ``load_extra('recentupdate', **kwargs)`` in the template, the
-following parameters are available:
+.. rst:directive:: .. recentupdate:: [count]
 
-``count``
-  Number of recent revisions to return (default from :confval:`recentupdate_count`).
+   Display recent document updates from Git.
 
-``paths``
-  A list of git pathspecs (:manpage:`gitglossary(7)`) to filter file changes
-  (default ``['.']``).
-  See also :example:`Recent Updates of Custom Path`.
+   The optional ``count`` is the number of recent revisions to display.
+   Defaults to :confval:`recentupdate_count`.
 
-``current_doc``
-  If ``True``, only return revisions that modified the current document
-  (default ``False``). 
+   .. rst:directive:option:: self
+      :type: flag
 
-  .. note::
+      Only show revisions that modified the current document.
+      Mutually exclusive with :rst:dir:`recentupdate:paths`.
 
-     When enabled, ``paths`` is overridden with a pathspec matching the current
-     document. So ``paths`` and ``current_doc`` are mutually exclusive.
+      See also :example:`Recent Updates to Current Document`.
 
-  See also :example:`Recent Updates to Current Document`.
+   .. rst:directive:option:: paths
+      :type: lines of str
 
-.. role:: py(code)
-  :language: Python
+      Git pathspecs (:manpage:`gitglossary(7)`) to filter file changes,
+      one per line. Defaults to ``.``.
 
-``group_by``
-  Group revisions by time period. Revisions are grouped by UTC time
-  period and author.
+      See also :example:`Recent Updates of Custom Path`.
 
-  Default from :confval:`recentupdate_group_by`, Available values:
-  :data.render:`{{ load_extra('env').config.values['recentupdate_group_by'].valid_types | autoconfval_types | join(', ') }}`.
+   .. rst:directive:option:: group-by
+      :type: str
 
-  See also :example:`Grouped Recent Updates`.
+      .. role:: py(code)
+        :language: Python
 
-Each item returned is a :py:class:`~sphinxnotes.recentupdate.Revision` object:
+      Group revisions by time period.
+      Available values:
+      :data.render:`{{ load_extra('env').config.values['recentupdate_group_by'].valid_types | autoconfval_types | join(', ') }}`.
+      Defaults to :confval:`recentupdate_group_by`.
+
+      See also :example:`Grouped Recent Updates`.
+
+   The directive body is a Jinja2 template. When empty,
+   :confval:`recentupdate_template` is used. The template context contains
+   a ``{{ revisions }}`` variable, it is a list of
+   :py:class:`~sphinxnotes.recentupdate.Revision` objects.
 
 .. autoclass:: sphinxnotes.recentupdate.Revision
 
@@ -55,6 +60,39 @@ Each item returned is a :py:class:`~sphinxnotes.recentupdate.Revision` object:
    .. autoattribute:: changed_docs
    .. autoattribute:: removed_docs
 
+This is a basic example using the default template:
+
+.. example::
+
+   .. recentupdate::
+
+The ``recentupdate`` Extra Context
+==================================
+
+.. tip::
+
+   The extra context is for use within `sphinxnotes-render`_ compatible templates.
+   In most cases, prefer the :rst:dir:`recentupdate` directive instead.
+
+The ``recentupdate`` extra context can be loaded via
+:external+render:term:`load_extra` in a Jinja template
+(e.g. via :rst:dir:`data.render`):
+
+Parameters:
+
+``count``
+   Equivalent to the argument of :rst:dir:`recentupdate`.
+
+``paths``
+   Equivalent to :rst:dir:`recentupdate:paths`.
+
+``self_only``
+   Equivalent to :rst:dir:`recentupdate:self`.
+
+``group_by``
+   Equivalent to :rst:dir:`recentupdate:group-by`.
+
+                    
 This is a basic example:
 
 .. example::
@@ -67,15 +105,18 @@ This is a basic example:
          {{ r.message[0] }}
       {% endfor %}
 
+.. note:: To Use the ``data.render`` directive, you need to add
+   ``sphinxnotes.render.ext`` to your Sphinx extension list.
+
 Examples
 ========
 
-.. example:: Show Which Files Updated
+.. example:: Show Which Documents Updated
 
-   .. data.render::
+   .. recentupdate::
 
-      {% for r in load_extra('recentupdate', count=5) %}
-      ``📅 {{ r.date.strftime('%Y-%m-%d') }}``
+      {% for r in revisions %}
+      ``{{ r.date.strftime('%Y-%m-%d') }}``
          {% if r.changed_docs -%}
          :Modified: {{ r.changed_docs | roles("doc") | join(", ") }}
          {% endif %}
@@ -87,41 +128,46 @@ Examples
          {% endif %}
       {% endfor %}
 
-      The aboved :external+render:term:`roles` filter is also provided by
-      `sphinxnotes-render`_.
+   The aboved :external+render:term:`roles` filter is also provided by
+   `sphinxnotes-render`_.
+
 
 .. example:: Recent Updates of Custom Path
 
-   .. data.render::
+   Recent changes of the :doc:`changelog`:
 
-      Recent changes of the :doc:`changelog`:
+   .. recentupdate::
+      :paths: docs/changelog.rst
 
-      {% for r in load_extra('recentupdate', count=5, paths=['docs/changelog.rst']) %}
+      {% for r in revisions %}
       ``{{ r.date.strftime('%Y-%m-%d') }}`` — {{ r.message[0] }}
       {% endfor %}
 
 .. example:: Recent Updates to Current Document
 
-   .. data.render::
+   Recent changes to this document:
 
-      Recent changes to this document:
+   .. recentupdate::
+      :self:
 
-      {% for r in load_extra('recentupdate', count=5, current_doc=True) %}
+      {% for r in revisions %}
       ``{{ r.date.strftime('%Y-%m-%d') }}`` — {{ r.message[0] }}
       {% endfor %}
 
 .. example:: Grouped Recent Updates
 
-   .. data.render::
+   Recent updates grouped by month:
 
-      Recent updates grouped by month:
+   .. recentupdate:: 3
+      :group-by: month
 
-      {% for r in load_extra('recentupdate', count=5, group_by='month') %}
+      {% for r in revisions %}
       ``📅 {{ r.date.strftime('%Y-%m') }}``
          ::
-            {% for msg in r.message %}
+            {% for msg in r.message[:20] %}
             {{ msg }}
             {%- endfor %}
+            ...
       {% endfor %}
 
 ``sphinxnotes-render``

--- a/src/sphinxnotes/recentupdate/__init__.py
+++ b/src/sphinxnotes/recentupdate/__init__.py
@@ -9,14 +9,17 @@ Get recent document revision info from git, exposed as render extra context.
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, ClassVar, Iterator, override
+from typing import TYPE_CHECKING, Iterator, override
 from datetime import datetime, timezone
 from dataclasses import dataclass
 from collections import OrderedDict
 from os import path
 from itertools import islice
+from textwrap import dedent
 
 from git import Repo
+
+from docutils.parsers.rst import directives
 
 from sphinx.util import logging
 from sphinx.config import ENUM
@@ -25,6 +28,9 @@ from sphinxnotes.render import (
     extra_context,
     ExtraContext,
     ExtraContextRequest,
+    BaseContextDirective,
+    Phase,
+    Template,
 )
 
 from . import meta
@@ -156,7 +162,7 @@ def get_git_revisions(
             # :T: change in the type of the file
             # :U: file is unmerged (you must complete the merge before it can be committed)
             # :X: "unknown" change type (most probably a bug, please report it)
-            status_maps = {'M': m, 'A': a, 'D': d }
+            status_maps = {'M': m, 'A': a, 'D': d}
 
             # Use git diff --name-status with pathspecs for native pathspec matching
             name_status = repo.git.diff(
@@ -190,65 +196,141 @@ def get_git_revisions(
 
 
 def path2doc(repo: Repo, env: BuildEnvironment, blob_path: str) -> str | None:
-    """Convert a git repo-relative blob path to a Sphinx document name. """
+    """Convert a git repo-relative blob path to a Sphinx document name."""
     docname = env.path2doc(path.join(repo.working_dir, blob_path))
     return docname if (docname and not path.isabs(docname)) else None
+
+
+def collect_revisions(
+    repo: Repo,
+    env: BuildEnvironment,
+    count: int | None,
+    paths: list[str],
+    group_by: str | None,
+) -> list[Revision]:
+    """Collect recent revisions from git, optionally grouped by time period."""
+    repo = CURRENT_REPO
+    count = count or env.config.recentupdate_count
+    group_by = group_by or env.config.recentupdate_group_by
+
+    git_revs = get_git_revisions(repo, env, paths)
+
+    if group_by:
+        groups = OrderedDict()
+        for rev in git_revs:
+            group_revisions(groups, rev, group_by)
+            if len(groups) >= count:
+                break
+        revs = compact_groups(groups)
+    else:
+        revs = list(islice(git_revs, count))
+    logger.info(
+        f'[recentupdate] Expect {count} revisions, finally get {len(revs)}, group by {group_by}'
+    )
+
+    return revs
+
+class RecentUpdateDirective(BaseContextDirective):
+    """Directive for displaying recent document updates."""
+
+    @staticmethod
+    def _group_by_choice(arg: str):
+        return directives.choice(arg, GROUP_BY_CHOICES)
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 1
+    option_spec = {
+        'self': directives.flag,
+        'paths': directives.unchanged,
+        'group-by': _group_by_choice,
+    }
+
+    def current_context(self) -> dict:
+        repo = CURRENT_REPO
+
+        count = int(self.arguments[0]) if self.arguments else None
+
+        if 'self' in self.options:
+            docpath = self.env.doc2path(self.env.docname)
+            paths = [path.relpath(docpath, repo.working_dir)]
+        elif 'paths' in self.options:
+            paths = [p.strip() for p in self.options['paths'].splitlines() if p.strip()]
+        else:
+            paths = []
+
+        group_by = self.options.get('group-by')
+
+        revs = collect_revisions(repo, self.env, count, paths, group_by)
+        return {'revisions': revs}
+
+    def current_template(self) -> Template:
+        text = '\n'.join(self.content)
+        if not text.strip():
+            text = self.env.config.recentupdate_template
+        return Template(text, phase=Phase.Parsing)
 
 
 @extra_context('recentupdate')
 class RecentUpdateExtraContext(ExtraContext):
     """Extra context providing recent document revisions from Git."""
 
-    repo: ClassVar[Repo]
-
     @override
     def generate(
         self,
         req: ExtraContextRequest,
-        count: int = 0,
-        paths: list[str] = ['.', ],
-        current_doc: bool = False,
-        group_by: str = '',
+        count: int | None = None,
+        paths: list[str] = [],
+        group_by: str | None = None,
+        self_only: bool = False,
     ) -> Any:
-        count = count or req.env.config.recentupdate_count
-        group_by = group_by or req.env.config.recentupdate_group_by
+        repo = CURRENT_REPO
 
-        if current_doc:
+        if self_only:
             docpath = req.env.doc2path(req.env.docname)
-            repo_path = path.relpath(docpath, self.repo.working_dir)
-            paths = [repo_path]
+            paths = [path.relpath(docpath, repo.working_dir)]
 
-        git_revs = get_git_revisions(self.repo, req.env, paths)
+        return collect_revisions(repo, req.env, count, paths, group_by)
 
-        if group_by:
-            groups = OrderedDict()
-            for rev in git_revs:
-                group_revisions(groups, rev, group_by)
-                if len(groups) >= count:
-                    break
-            revs = compact_groups(groups)
-        else:
-            revs = list(islice(git_revs, count))
-        logger.info(
-            f'[recentupdate] Expect {count} revisions, finally get {len(revs)}, group by {group_by}'
-        )
 
-        return revs
+CURRENT_REPO: Repo
+GROUP_BY_CHOICES = ['day', 'month', 'year']
+DEFAULT_TEMPLATE = dedent("""\
+    {% for r in revisions %}
+    ``👤 {{ r.author }}`` @ ``📅 {{ r.date.strftime('%Y-%m-%d') }}``
+       ::
 
+          {{ r.message[0] }}
+
+       {% if r.changed_docs -%}
+       - Modified {{ r.changed_docs | roles("doc") | join(", ") }}
+       {% endif %}
+       {% if r.added_docs -%}
+       - Added {{ r.added_docs | roles("doc") | join(", ") }}
+       {% endif %}
+       {% if r.removed_docs -%}
+       - Deleted {{ r.removed_docs | join(", ") }}
+       {% endif %}
+    {% endfor %}
+    """)
 
 def setup(app: Sphinx):
     meta.pre_setup(app)
 
-    RecentUpdateExtraContext.repo = Repo(app.srcdir, search_parent_directories=True)
+    global CURRENT_REPO
+    CURRENT_REPO = Repo(app.srcdir, search_parent_directories=True)
 
     app.setup_extension('sphinxnotes.render')
+
+    app.add_directive('recentupdate', RecentUpdateDirective)
 
     app.add_config_value(
         'recentupdate_exclude_commit', ['skip-recentupdate'], 'env', types=list[str]
     )
-    app.add_config_value('recentupdate_count', 10, 'env', types=int)
+    app.add_config_value('recentupdate_count', 5, 'env', types=int)
+    app.add_config_value('recentupdate_template', DEFAULT_TEMPLATE, 'env', types=str)
     app.add_config_value(
-        'recentupdate_group_by', None, 'env', types=ENUM(None, 'day', 'month', 'year')
+        'recentupdate_group_by', None, 'env', types=ENUM(None, *GROUP_BY_CHOICES)
     )
 
     return meta.post_setup(app)

--- a/tests/roots/test-recentupdate-current-doc/index.rst
+++ b/tests/roots/test-recentupdate-current-doc/index.rst
@@ -4,7 +4,7 @@ Recentupdate Current Doc Test
 .. data.render::
    :debug:
 
-   {% for r in load_extra('recentupdate', count=10, current_doc=True) %}
+   {% for r in load_extra('recentupdate', count=10, self_only=True) %}
    Commit: {{ r.message[0] }}
    {% endfor %}
 


### PR DESCRIPTION
## Summary

- Add `recentupdate` directive using `BaseContextDirective` from sphinxnotes-render
- Extract `collect_revisions()` shared helper for directive and extra context
- Restore `recentupdate_template` config value as default template when directive body is empty

## Directive Usage

```rst
.. recentupdate:: [count]
   :self:
   :paths:
      docs/changelog.rst

   custom jinja template
```

- Argument `count`: optional, defaults to `recentupdate_count` config
- Option `:self:`: only revisions affecting current document
- Option `:paths:`: git pathspecs, one per line
- Body: Jinja template with `revisions` context, falls back to `recentupdate_template`

Co-authored-by: MiMoCode <mimo@xiaomi.com>